### PR TITLE
Ak/pay to validator hash

### DIFF
--- a/docs/src/plutus-v2.md
+++ b/docs/src/plutus-v2.md
@@ -17,7 +17,8 @@ data DatumMode a
   = HashDatum a      -- ^ store datum hash in TxOut
   | InlineDatum a    -- ^ store inlined datum value in TxOut
 
-payToScript :: IsValidator script => script -> DatumMode (DatumType script) -> Value -> Tx
+payToScript :: (HasAddress script, HasDatum script) => 
+  script -> DatumMode (DatumType script) -> Value -> Tx
 ```
 
 Example from the code:

--- a/docs/src/staking.md
+++ b/docs/src/staking.md
@@ -22,7 +22,7 @@ So we can use the same functions with scritps that have some staking info attach
 Let's recall the type:
 
 ```haskell
-payToScript :: (IsValidator v) => v -> DatumType v -> Value -> Tx
+payToScript :: (HasAddress v, HasDatum v) => v -> DatumType v -> Value -> Tx
 ```
 
 The same function exists to pay to pub key hash:

--- a/docs/src/test-scripts.md
+++ b/docs/src/test-scripts.md
@@ -74,16 +74,17 @@ data DatumMode a
   | InlineDatum a    -- ^ store inlined datum value in TxOut
 
 payToScript :: 
-     IsValidator script 
+     (HasAddress script, HashDatum script)
   => script 
   -> DatumMode (DatumType script) 
   -> Value 
   -> Tx
 ```
 
-So it uses validator, datum for it (of proper type) and value to protect with the contract.
+So it uses address of the validator, datum for it (of proper type) and value to protect with the contract.
 As simple as that. Our type `Game` is `TypedValidator GameDatum GameRedeemer` and
 for typed valdiator first tpye argument corresponds to `DatumType`.
+As input we can use `TypedValidator`, `TypedValidatorHash` and `AppendStaking`-wrappers.
 
 Note that in example we wrap it in `HashDatum`. Starting from Babbage era 
 we can store not only datum hashes in `TxOut` but also we can inline datum values

--- a/src/Plutus/Model/Contract.hs
+++ b/src/Plutus/Model/Contract.hs
@@ -355,7 +355,7 @@ payToKey pkh val = toExtra $
 
 -- | Pay to the script.
 -- We can use TypedValidator as argument and it will be checked that the datum is correct.
-payToScript :: (IsValidator script) =>
+payToScript :: (HasDatum script, HasAddress script) =>
   script -> DatumMode (DatumType script) -> Value -> Tx
 payToScript script dat val = toExtra $
   mempty
@@ -388,7 +388,7 @@ loadRefScriptBy script mDat val = toExtra $
     (outDatum, datumMap) = maybe (NoOutputDatum, M.empty) fromDatumMode mDat
 
 -- | Pays to the TxOut that references some script stored on ledger
-payToRef :: (IsValidator script) =>
+payToRef :: (HasAddress script, HasDatum script) =>
   script -> DatumMode (DatumType script) -> Value -> Tx
 payToRef script dat val = toExtra $
   mempty

--- a/src/Plutus/Model/Validator.hs
+++ b/src/Plutus/Model/Validator.hs
@@ -1,9 +1,20 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# Language UndecidableInstances #-}
 module Plutus.Model.Validator(
+  IsData,
+  HasDatum(..),
+  HasRedeemer(..),
+  HasLanguage(..),
+  HasValidator(..),
+  HasValidatorHash(..),
+
+  IsValidator,
+  IsValidatorHash,
+
   TypedValidator(..),
+  TypedValidatorHash(..),
   TypedPolicy(..),
   TypedStake(..),
-  IsValidator(..),
   -- * Versioned
   Versioned(..),
   toV1,
@@ -39,90 +50,151 @@ import Plutus.Model.Fork.TxExtra qualified as Fork
 import Plutus.Model.Fork.Ledger.Scripts (Versioned(..), dataHash, datumHash, redeemerHash, toV1, toV2, isV1, isV2)
 import Plutus.Model.Fork.Ledger.Scripts qualified as Fork
 
--- | Class for typed vlaidators with versioning by Plutus language
-class (HasAddress script, ToData (DatumType script), FromData (DatumType script), ToData (RedeemerType script), FromData (RedeemerType script))
-  => IsValidator script where
-  type DatumType script    :: Type
-  type RedeemerType script :: Type
-  toValidator :: script -> Validator
-  -- ^ Get internal alidator
-  getLanguage :: script -> C.Language
+type IsData a = (ToData a, FromData a)
+
+class IsData (DatumType a) => HasDatum a where
+  type DatumType a :: Type
+
+class IsData (RedeemerType a) => HasRedeemer a where
+  type RedeemerType a :: Type
+
+class HasLanguage a where
+  getLanguage :: a -> C.Language
   -- ^ Get plutus language version
 
-instance (ToData datum, FromData datum, ToData redeemer, FromData redeemer)
-  => IsValidator (TypedValidator datum redeemer) where
+class HasValidator a where
+  toValidator :: a -> Validator
+  -- ^ Get internal avlidator
+
+class HasValidatorHash a where
+  toValidatorHash :: a -> ValidatorHash
+  -- ^ Get internal avlidator
+
+type IsValidator a = (HasAddress a, HasDatum a, HasRedeemer a, HasLanguage a, HasValidator a)
+type IsValidatorHash a = (HasAddress a, HasDatum a, HasRedeemer a, HasLanguage a, HasValidatorHash a)
+
+instance HasLanguage (Versioned a) where
+  getLanguage (Versioned lang _) = lang
+
+instance (HasLanguage a, HasValidator a) => HasValidatorHash a where
+  toValidatorHash v = Fork.validatorHash $ Versioned (getLanguage v) (toValidator v)
+
+---------------------------------------------------------------------
+-- typed validator
+
+-- | Typed validator. It's phantom type to annotate types for validators
+newtype TypedValidator datum redeemer =
+  TypedValidator { unTypedValidator :: Versioned Validator }
+  deriving newtype (HasLanguage)
+
+instance IsData datum => HasDatum (TypedValidator datum redeemer) where
   type DatumType (TypedValidator datum redeemer) = datum
+
+instance IsData redeemer => HasRedeemer (TypedValidator datum redeemer) where
   type RedeemerType (TypedValidator datum redeemer) = redeemer
+
+instance HasValidator (TypedValidator datum redeemer) where
   toValidator (TypedValidator (Versioned _lang validator)) = validator
-  getLanguage = versioned'language . unTypedValidator
 
-instance (IsValidator script, ToData (DatumType script), FromData (DatumType script), ToData (RedeemerType script), FromData (RedeemerType script))
-  => IsValidator (AppendStaking script) where
-  type DatumType (AppendStaking script)    = DatumType script
-  type RedeemerType (AppendStaking script) = RedeemerType script
-  toValidator (AppendStaking _ script) = toValidator script
-  getLanguage (AppendStaking _ script) = getLanguage script
+instance HasAddress (TypedValidator datum redeemer) where
+  toAddress = toAddress . toValidatorHash
 
-instance (ToData redeemer, FromData redeemer) => IsValidator (TypedPolicy redeemer) where
-  type DatumType (TypedPolicy redeemer) = ()
+---------------------------------------------------------------------
+-- typed validator hash
+
+-- | Typed validator. It's phantom type to annotate types for validators
+newtype TypedValidatorHash datum redeemer =
+  TypedValidatorHash { unTypedValidatorHash :: Versioned ValidatorHash }
+  deriving newtype (HasLanguage)
+
+instance IsData datum => HasDatum (TypedValidatorHash datum redeemer) where
+  type DatumType (TypedValidatorHash datum redeemer) = datum
+
+instance IsData redeemer => HasRedeemer (TypedValidatorHash datum redeemer) where
+  type RedeemerType (TypedValidatorHash datum redeemer) = redeemer
+
+instance HasValidatorHash (TypedValidatorHash datum redeemer) where
+  toValidatorHash (TypedValidatorHash (Versioned _lang vh)) = vh
+
+instance HasAddress (TypedValidatorHash datum redeemer) where
+  toAddress (TypedValidatorHash (Versioned _lang vh)) = toAddress vh
+
+---------------------------------------------------------------------
+-- typed policy
+
+-- | Typed minting policy. It's phantom type to annotate types for minting policies
+newtype TypedPolicy redeemer =
+  TypedPolicy { unTypedPolicy :: Versioned MintingPolicy }
+  deriving newtype (HasLanguage)
+
+instance IsData redeemer => HasRedeemer (TypedPolicy redeemer) where
   type RedeemerType (TypedPolicy redeemer) = redeemer
+
+instance HasValidator (TypedPolicy redeemer) where
   toValidator (TypedPolicy (Versioned _lang (MintingPolicy script))) = Validator script
-  getLanguage = versioned'language . unTypedPolicy
+
+instance HasAddress (TypedPolicy redeemer) where
+  toAddress = toAddress . toValidatorHash
+
+---------------------------------------------------------------------
+-- typed stake
+
+-- | Typed stake valdiators. It's phantom type to annotate types for stake valdiators
+newtype TypedStake redeemer =
+  TypedStake { unTypedStake :: Versioned StakeValidator }
+  deriving newtype (HasLanguage)
+
+instance IsData redeemer => HasRedeemer (TypedStake redeemer) where
+  type RedeemerType (TypedStake redeemer) = redeemer
+
+instance HasValidator (TypedStake redeemer) where
+  toValidator (TypedStake (Versioned _lang (StakeValidator script))) = Validator script
+
+instance HasStakingCredential (TypedStake redeemer) where
+  toStakingCredential (TypedStake script) = Fork.scriptToStaking script
+
+instance HasAddress (TypedStake redeemer) where
+  toAddress = toAddress . toValidatorHash
+
+---------------------------------------------------------------------
+-- append staking
+
+instance {-# overlapping #-} IsData (DatumType a) => HasDatum (AppendStaking a) where
+  type DatumType (AppendStaking a) = DatumType a
+
+instance {-# overlapping #-} IsData (RedeemerType a) => HasRedeemer (AppendStaking a) where
+  type RedeemerType (AppendStaking a) = RedeemerType a
+
+instance {-# overlapping #-} HasLanguage a => HasLanguage (AppendStaking a) where
+  getLanguage (AppendStaking _ a) = getLanguage a
+
+instance {-# overlapping #-} HasValidator a => HasValidator (AppendStaking a) where
+  toValidator (AppendStaking _ a) = toValidator a
+
+---------------------------------------------------------------------
+-- utils
 
 -- | Converts typed validator to versioned script
 toVersionedScript :: IsValidator a => a -> Versioned Script
 toVersionedScript a = Versioned (getLanguage a) (getValidator $ toValidator a)
 
 -- | Get valdiator hash
-validatorHash :: IsValidator a => a -> ValidatorHash
-validatorHash v = Fork.validatorHash $ Versioned (getLanguage v) (toValidator v)
+validatorHash :: (HasLanguage a, HasValidator a) => a -> ValidatorHash
+validatorHash v = coerce $ Fork.validatorHash $ Versioned (getLanguage v) (toValidator v)
 
 -- | Get script hash
-scriptHash :: IsValidator a => a -> ScriptHash
-scriptHash = coerce . validatorHash
-
--- | Typed validator. It's phantom type to annotate types for validators
-newtype TypedValidator datum redeemer =
-  TypedValidator { unTypedValidator :: Versioned Validator }
-
-instance (ToData datum, ToData redeemer, FromData datum, FromData redeemer)
-  => HasAddress (TypedValidator datum redeemer) where
-  toAddress = toAddress . validatorHash
-
--- | Typed minting policy. It's phantom type to annotate types for minting policies
-data TypedPolicy redeemer =
-  TypedPolicy { unTypedPolicy :: Versioned MintingPolicy }
-
-instance (ToData redeemer, FromData redeemer) => HasAddress (TypedPolicy redeemer) where
-  toAddress = toAddress . validatorHash
-
--- | Typed stake valdiators. It's phantom type to annotate types for stake valdiators
-newtype TypedStake redeemer =
-  TypedStake { unTypedStake :: Versioned StakeValidator }
-
-instance (ToData redeemer, FromData redeemer) => IsValidator (TypedStake redeemer) where
-  type DatumType (TypedStake redeemer) = ()
-  type RedeemerType (TypedStake redeemer) = redeemer
-  toValidator (TypedStake (Versioned _lang (StakeValidator script))) = Validator script
-  getLanguage = versioned'language . unTypedStake
-
-instance (ToData redeemer, FromData redeemer) => HasAddress (TypedStake redeemer) where
-  toAddress = toAddress . validatorHash
-
-instance HasStakingCredential (TypedStake redeemer) where
-  toStakingCredential (TypedStake script) = Fork.scriptToStaking script
-
----------------------------------------------------------------------------------
+scriptHash :: (HasLanguage a, HasValidator a) => a -> ScriptHash
+scriptHash v = coerce $ Fork.validatorHash $ Versioned (getLanguage v) (toValidator v)
 
 -- | Get currency symbol for minting policy
 scriptCurrencySymbol :: TypedPolicy a -> CurrencySymbol
 scriptCurrencySymbol (TypedPolicy script) = Fork.scriptCurrencySymbol script
 
--- | Get minting policy hash
-mintingPolicyHash :: TypedPolicy a -> MintingPolicyHash
-mintingPolicyHash (TypedPolicy script) = Fork.mintingPolicyHash script
-
 -- | Get stake vlaidator hash
 stakeValidatorHash :: TypedStake a -> StakeValidatorHash
 stakeValidatorHash (TypedStake script) = Fork.stakeValidatorHash script
+
+-- | Get minting policy hash
+mintingPolicyHash :: TypedPolicy a -> MintingPolicyHash
+mintingPolicyHash (TypedPolicy script) = Fork.mintingPolicyHash script
 


### PR DESCRIPTION
Relaxes constraints on `payToScript` for usage with pay by `ValidatorHash`
Also splits `IsValidator` class on sub classes and introduces wrapper `TypedValidatorHash`