### PR TITLE
Fix check balance with ref. scripts

### DIFF
--- a/src/Plutus/Model/Contract.hs
+++ b/src/Plutus/Model/Contract.hs
@@ -766,10 +766,11 @@ checkBalanceBy :: (a -> BalanceDiff) -> Run a -> Run a
 checkBalanceBy getDiffs act = do
   beforeSt <- get
   res <- act
+  afterSt <- get
   let BalanceDiff diffs = getDiffs res
       addrs = M.keys diffs
       before =  fmap (`valueAtState` beforeSt) addrs
-  after <- mapM valueAt addrs
+      after = fmap (`valueAtState` afterSt) addrs
   mapM_ (logError . show . vcat <=< mapM ppError) (check addrs diffs before after)
   pure res
   where


### PR DESCRIPTION
This PR fixes the function `checkBalance` used to check changes in balance for specified addresses after some transaction.

The problem was that UTxOs carrying reference scripts were being accounted for in the initial state but not in the final state.