### PR TITLE
Expose `Tx`

### DIFF
--- a/plutus-simple-model.cabal
+++ b/plutus-simple-model.cabal
@@ -125,6 +125,7 @@ library
     Plutus.Model.Mock.Stat
     Plutus.Model.Pretty
     Plutus.Model.Stake
+    Plutus.Model.Tx
     Plutus.Model.V1
     Plutus.Model.V2
     Plutus.Model.Validator

--- a/src/Plutus/Model/Tx.hs
+++ b/src/Plutus/Model/Tx.hs
@@ -1,0 +1,21 @@
+module Plutus.Model.Tx (
+  Tx.Tx (
+    Tx,
+    txInputs,
+    txCollateral,
+    txReferenceInputs,
+    txOutputs,
+    txCollateralReturn,
+    txTotalCollateral,
+    txMint,
+    txFee,
+    txValidRange,
+    txMintScripts,
+    txSignatures,
+    txRedeemers,
+    txData,
+    txScripts
+  ),
+) where
+
+import Plutus.Model.Fork.Ledger.Tx qualified as Tx


### PR DESCRIPTION
This is needed, because Apropos needs fine-grained control over Tx generation.