### PR TITLE
Don't spend output with datum

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to the [Haskell Package Versioning Policy](https://pvp.haskell.org/).
 
+## [0.5.0.0] - 2022-12-18
+
+### Changed
+
+- `Contract.spend'`,`Contract.sendValue`, `Contract.withSpend`, `Contract.spend` wil now not spend UTxOs that have a datum.
+
+- A `HasCallStack` constraint has been added to `spend`.
+
 ## [0.4.0.0] - 2022-12-13
 
 ### Changed

--- a/plutus-simple-model.cabal
+++ b/plutus-simple-model.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               plutus-simple-model
-version:            0.4.0.0
+version:            0.5.0.0
 synopsis:           Unit test library for plutus
 description:        Unit test library for plutus with resource estimation
 homepage:           https://github.com/mlabs-haskell/plutus-simple-model

--- a/src/Plutus/Model/Contract.hs
+++ b/src/Plutus/Model/Contract.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE UndecidableInstances #-}
-{-# OPTIONS_GHC -Wno-redundant-constraints #-}
 
 -- | Functions to create TXs and query blockchain model.
 module Plutus.Model.Contract (
@@ -271,7 +270,7 @@ getHeadRef :: UserSpend -> TxOutRef
 getHeadRef UserSpend {..} = Fork.txInRef $ S.elemAt 0 userSpend'inputs
 
 -- | Variant of spend' that fails in run-time if there are not enough funds to spend.
-spend :: (HasCallStack) => PubKeyHash -> Value -> Run UserSpend
+spend :: PubKeyHash -> Value -> Run UserSpend
 spend pkh val = do
   mSp <- spend' pkh val
   pure $ fromJust mSp


### PR DESCRIPTION
If a wallet UTxO holds a datum, it is presumably earmarked for a specific purpose. as such, the `spend` function should not spend it.